### PR TITLE
Fix: don't set upper bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["kolibril13 <44469195+kolibril13@users.noreply.github.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = "^3.8"
 ipython = ">=7.0.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["kolibril13 <44469195+kolibril13@users.noreply.github.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8,<3.11"
 ipython = ">=7.0.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.8"
 jupyterlab = ">=3.3.0"
+ipython = ">=7.0.0"
 
 [tool.poetry.dev-dependencies]
 black = {extras = ["jupyter"], version = ">=22.3.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,16 @@ authors = ["kolibril13 <44469195+kolibril13@users.noreply.github.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8,<3.11"
-ipykernel = "^6.13.0"
-jupyterlab = "^3.3.4"
+python = ">=3.8"
+jupyterlab = ">=3.3.0"
 
 [tool.poetry.dev-dependencies]
-black = {extras = ["jupyter"], version = "^22.3.0"}
-matplotlib = "^3.5.1"
-scipy = "^1.8.0"
-scikit-image = "^0.19.2"
-pytest = "^7.1.2"
-isort = "^5.10.1"
+black = {extras = ["jupyter"], version = ">=22.3.0"}
+matplotlib = ">=3.5.1"
+scipy = ">=1.8.0"
+scikit-image = ">=0.19.2"
+pytest = ">=7.1.2"
+isort = ">=5.10.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-jupyterlab = ">=3.3.0"
 ipython = ">=7.0.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Upper bounds are problematic in the Python ecosystem: https://iscinumpy.dev/post/bound-version-constraints/

Also, I've removed `ipykernel` as a dependency, and replaced it with `IPython`