### PR TITLE
Repace pkg_resources with importlib.metadata

### DIFF
--- a/jupyter_compare_view/__init__.py
+++ b/jupyter_compare_view/__init__.py
@@ -1,9 +1,9 @@
 from IPython import get_ipython
-import pkg_resources
+import importlib.metadata
 from .compare import compare, StartMode
 from .sw_cellmagic import CompareViewMagic
 
-__version__: str = pkg_resources.get_distribution(__name__).version
+__version__: str = importlib.metadata.version(__name__)
 
 
 try:


### PR DESCRIPTION
I think this is the only change needed to get rid of the dependence on pkg_resources. However, I can't really fully test this because I am not a user of this library. I hope it works!